### PR TITLE
Version 2.3 of the SOAP API can be safely used

### DIFF
--- a/lib/markety/client.rb
+++ b/lib/markety/client.rb
@@ -1,5 +1,5 @@
 module Markety
-  def self.new_client(access_key, secret_key, end_point, api_version = '2_2')
+  def self.new_client(access_key, secret_key, end_point, api_version = '2_3')
     client = Savon.client do
       endpoint end_point
       wsdl "http://app.marketo.com/soap/mktows/#{api_version}?WSDL"


### PR DESCRIPTION
The difference between version [2.2](http://app.marketo.com/soap/mktows/2_2?WSDL) and [2.3](http://app.marketo.com/soap/mktows/2_3?WSDL) of the WSDL contract<sup>†</sup> is subtle enough not to affect the current codebase.

<sup>†</sup>_addition of `activityNameFilter` to the `GetLeadChanges` params and the removal of `skipActivityLog` from the `ListOperation` params_
