### PR TITLE
Allow optionally turning off XML logging

### DIFF
--- a/lib/markety/client.rb
+++ b/lib/markety/client.rb
@@ -1,8 +1,10 @@
 module Markety
   def self.new_client(access_key, secret_key, end_point, options = {})
+    api_version = options.fetch(:api_version, '2_3')
+
     client = Savon.client do
       endpoint end_point
-      wsdl "http://app.marketo.com/soap/mktows/2_3?WSDL"
+      wsdl "http://app.marketo.com/soap/mktows/#{api_version}?WSDL"
       env_namespace "SOAP-ENV"
       namespaces({"xmlns:ns1" => "http://www.marketo.com/mktows/"})
       pretty_print_xml true


### PR DESCRIPTION
XML logging is great for testing but once confirmed working, it outputs too much text. This allows for passing an options hash to the client in the form of `{log: false}` to turn it off. 
