### PR TITLE
Remove support for Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 rvm:
   - 2.0.0
   - 2.1.1
+  - 2.2.0
 
 script: 'bundle exec rake'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.1
 

--- a/markety.gemspec
+++ b/markety.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_development_dependency  'bundler', '~> 1.6'
   s.add_development_dependency  'rake'


### PR DESCRIPTION
We're now using some Ruby >= 2 syntax and since Ruby 1.9.3 is no longer being supported, we're no longer supporting it as well.